### PR TITLE
absorb leading and trailing whitespace in a document

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       image: ubuntu-2204:current
     steps:
       - checkout
-      - run:
+      - run: sudo apt-get update &&
           sudo apt-get install binutils git gnupg2 libc6-dev libcurl4-openssl-dev libedit2 libgcc-9-dev libpython3.8 libsqlite3-0 libstdc++-9-dev libxml2-dev libz3-dev pkg-config tzdata unzip zlib1g-dev &&
           wget https://download.swift.org/swift-5.8.1-release/ubuntu2204/swift-5.8.1-RELEASE/swift-5.8.1-RELEASE-ubuntu22.04.tar.gz &&
           wget https://download.swift.org/swift-5.8.1-release/ubuntu2204/swift-5.8.1-RELEASE/swift-5.8.1-RELEASE-ubuntu22.04.tar.gz.sig &&

--- a/Sources/AutoGraphParser/IntrospectionTypes.swift
+++ b/Sources/AutoGraphParser/IntrospectionTypes.swift
@@ -465,7 +465,7 @@ public struct UnionType: __TypeConstructable {
 /// - `description` may return a `String` or `null`.
 /// - `fields` must return the set of fields required by this interface.
 ///   - Accepts the argument `includeDeprecated` which defaults to `false`. If `true`, deprecated fields are also returned.
-/// - `interfaces` must return the set of interfaces that an object implements (if none, interfaces must return the empty set).
+/// - `interfaces` must return the set of interfaces that an interface implements (if none, interfaces must return the empty set).
 /// - `possibleTypes` returns the list of types that implement this interface. They must be object types.
 /// - `All other fields must return `null`.
 public struct InterfaceType: __TypeConstructable {

--- a/Sources/AutoGraphParser/Language.swift
+++ b/Sources/AutoGraphParser/Language.swift
@@ -30,9 +30,14 @@ public struct ExecutableDocument: Hashable {
     }
     
     public static var parser: some Parser<Substring.UTF8View, Self> {
-        Many {
-            ExecutableDefinition.parser
-        } separator: {
+        // A document may have leading and trailing whitespace.
+        Parse {
+            Whitespace()
+            Many {
+                ExecutableDefinition.parser
+            } separator: {
+                Whitespace()
+            }
             Whitespace()
         }
         .map { ExecutableDocument(executableDefinitions: $0) }

--- a/Tests/AutoGraphParserTests/QueryLanguageParsingTests.swift
+++ b/Tests/AutoGraphParserTests/QueryLanguageParsingTests.swift
@@ -705,10 +705,32 @@ final class QueryLanguageParsingTests: XCTestCase {
     func testExecutableDocument() throws {
         /// ExecutableDocument:
         ///   ExecutableDefinition_list
-        let input = """
+        var input = """
         fragment CoolFragment_1234 on Some_Type_1234 { field } mutation Some_Op_1234 { field } query { field }
         """
-        let executableDocument = try ExecutableDocument.parser.parse(input)
+        var executableDocument = try ExecutableDocument.parser.parse(input)
+        XCTAssertEqual(
+            executableDocument,
+            ExecutableDocument(executableDefinitions: [
+                .fragmentDefinition(
+                    FragmentDefinition(name: "CoolFragment_1234", typeCondition: TypeCondition(name: NamedType(name: "Some_Type_1234")), directives: nil, selectionSet: SelectionSet(selections: [.field(Field(alias: nil, name: "field", arguments: nil, directives: nil, selectionSet: nil))]))
+                ),
+                .operationDefinition(
+                    OperationDefinition(operation: .mutation, name: "Some_Op_1234", variableDefinitions: nil, directives: nil, selectionSet: SelectionSet(selections: [.field(Field(alias: nil, name: "field", arguments: nil, directives: nil, selectionSet: nil))]))
+                ),
+                .operationDefinition(
+                    OperationDefinition(operation: .query, name: nil, variableDefinitions: nil, directives: nil, selectionSet: SelectionSet(selections: [.field(Field(alias: nil, name: "field", arguments: nil, directives: nil, selectionSet: nil))]))
+                )
+            ])
+        )
+        
+        // Inlude some newlines.
+        input = """
+        \nfragment CoolFragment_1234 on Some_Type_1234 { field }
+        mutation Some_Op_1234 { field }
+        query { field }\n
+        """
+        executableDocument = try ExecutableDocument.parser.parse(input)
         XCTAssertEqual(
             executableDocument,
             ExecutableDocument(executableDefinitions: [


### PR DESCRIPTION
would fail with whitespace at the beginning or end of a document